### PR TITLE
refactor: Handle no posts scenario in UpdatePostsOnAppStruct

### DIFF
--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -156,11 +156,6 @@ func main() {
 		}
 	}
 
-	err = app.createPrivatePostsIfNoPostsExist()
-	if err != nil {
-		logger.Error("Unable to create private posts", "error", err)
-	}
-
 	srv := &http.Server{
 		Addr:         ":" + cfg.port,
 		Handler:      app.routes(),


### PR DESCRIPTION
This commit refactors the UpdatePostsOnAppStruct function to handle the scenario where there are no posts in the database. Instead of returning an error, it now creates a dummy post. The function createPrivatePostsIfNoPostsExist is removed as it is no longer needed. This change simplifies the code and improves its readability.